### PR TITLE
possible layout

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,7 +25,7 @@ default['falcon']['sensor_tmp_dir'] = case node['kernel']['name']
 
 
 # falcon::config
-default['falcon']['client_id'] = nil
+default['falcon']['cid'] = nil
 default['falcon']['provisioning_token'] = nil
 default['falcon']['proxy_host'] =  nil
 default['falcon']['proxy_port'] = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,43 @@
+# falcon::install
+default['falcon']['package_name'] = case node['kernel']['name']
+                                    when 'Linux'
+                                      'falcon-sensor'
+                                    when 'windows'
+                                      'CrowdStrike Falcon Sensor'
+                                    else
+                                      'falcon'
+                                    end
+default['falcon']['install_method'] = 'api'
+default['falcon']['cleanup_installer'] = true
+default['falcon']['client_id'] = nil
+default['falcon']['client_secret'] = nil
+default['falcon']['falcon_cloud'] = 'api.crowdstrike.com' # should we use us-1, us-2 naming?
+default['falcon']['version'] = nil
+default['falcon']['version'] = nil
+default['falcon']['update_policy'] = nil
+default['falcon']['version_decrement'] = 0
+default['falcon']['sensor_tmp_dir'] = case node['kernel']['name']
+                                      when 'windows'
+                                        'C:\\windows\\temp'
+                                      else
+                                        '/tmp'
+                                      end
+
+
+# falcon::config
+default['falcon']['client_id'] = nil
+default['falcon']['provisioning_token'] = nil
+default['falcon']['proxy_host'] =  nil
+default['falcon']['proxy_port'] = nil
+default['falcon']['proxy_enabled'] = nil
+default['falcon']['tags'] = []
+
+# falcon::service
+default['falcon']['service_name'] = case node['kernel']['name']
+                                    when 'Linux'
+                                      'falcon-sensor'
+                                    when 'windows'
+                                      'CSFalconService'
+                                    else
+                                      'com.crowdstrike.falcon.UserAgent'
+                                    end

--- a/resources/falcon_install.rb
+++ b/resources/falcon_install.rb
@@ -1,0 +1,28 @@
+provides :falcon_install
+unified_mode true
+
+action :install do
+  case node['platform_family']
+  when 'mac_os_x'
+    log 'not yet implemented'
+  when 'windows'
+    log 'not yet implemented'
+  else
+    falcon_install_linux 'Install Falcon Sensor' do
+      action :install
+    end
+  end
+end
+
+action :remove do
+  case node['platform_family']
+  when 'mac_os_x'
+    log 'not yet implemented'
+  when 'windows'
+    log 'not yet implemented'
+  else
+    falcon_install_linux 'Remove Falcon Sensor' do
+      action :remove
+    end
+  end
+end

--- a/resources/falcon_install_linux.rb
+++ b/resources/falcon_install_linux.rb
@@ -1,0 +1,12 @@
+provides :falcon_install_linux
+unified_mode true
+
+use 'partial/_common'
+
+action :install do
+  log 'not yet implemented'
+end
+
+action :remove do
+  log 'not yet implemented'
+end


### PR DESCRIPTION
Possible layout of our cookbook

`partial/_*` contains properties that we may want to share. For example both windows and linux support tags being configured after install time

`falcon_install` main resource that will be called to install the falcon sensor. This resource will call the appropriate os specific resource since each OS requires different properties at install time. For example proxy settings for windows need to be passed at install time, but linux will be configured by `falconctl` or `falcon_config` (to match naming other cookbooks use.

You can checkout the `java` cookbook they are doing something similar. I've seen a few other too. If windows/windows/macos wasn't so different we could have a single `falcon_install`.

Just throwing this out there to get us thinking. The puppet module went through many module redesigns during the initial development and because of that the final result is something I am very happy with. I expect we will do the same here.