### PR TITLE
Separate linting from integration testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
----
 name: "Integration Tests"
 on:
   push:
@@ -16,17 +15,7 @@ on:
       - 'ohai/**'
 
 jobs:
-  lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
-    permissions:
-      actions: write
-      checks: write
-      pull-requests: write
-      statuses: write
-      issues: write
-
   integration:
-    needs: lint-unit
     if: |
       github.event_name == 'push' ||
       github.event_name == 'schedule' ||

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,14 @@
+name: "Lint Tests"
+
+on:
+  push
+
+jobs:
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
+    permissions:
+      actions: write
+      checks: write
+      pull-requests: write
+      statuses: write
+      issues: write


### PR DESCRIPTION
This PR splits linting from the integration tests. We would like to ensure all PR's on push events trigger a lint action to run.