### PR TITLE
Unorderd list mdl rule has no impact and is hit/miss

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,1 +1,2 @@
 rules '~MD013'
+rules '~MD007'


### PR DESCRIPTION
ignore MD007 unordered list rule for markdownlint.