### PR TITLE
Add local install_method to install falcon from local file source

### DIFF
--- a/documentation/falcon_install.md
+++ b/documentation/falcon_install.md
@@ -22,7 +22,8 @@ The Default action is `:install`
 | version_decrement | Integer | `0` | The number of versions to decrement the desired version by
 | falcon_cloud | String | `api.crowdstrike.com` | The Falcon API cloud to use
 | cleanup_installer | [true, false] | `true` | Whether or not to cleanup the installer after installation
-| install_method | ['api'] | `api` | The method to use to install the Falcon sensor
+| install_method | ['api', 'local'] | `api` | The method to use to install the Falcon sensor
+| package_source | String |  | The path to the package in the local file system
 | sensor_tmp_dir | String | `/tmp` | The directory to stage the Falcon package in
 
 ## Example
@@ -41,6 +42,14 @@ falcon_install 'falcon' do
   client_secret 'SDLKFJLKSJDFLKJSDFLK'
   falcon_cloud 'api.us-2.crowdstrike.com'
   update_policy 'ACME Policy'
+  action :install
+end
+```
+
+```ruby
+falcon_install 'falcon' do
+  install_method 'local'
+  package_source '/tmp/falcon-sensor.rpm'
   action :install
 end
 ```

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -94,3 +94,6 @@ suites:
       - recipe[test::config_delete]
     provisioner:
       enforce_idempotency: false
+  - name: install_local
+    run_list:
+      - recipe[test::install_local]

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -22,7 +22,7 @@ property :cleanup_installer, [true, false], default: true, desired_state: false,
 property :install_method, String, equal_to: %w(api local), default: 'api', desired_state: false,
           description: 'The method to use to install the Falcon sensor'
 property :package_source, String, desired_state: false,
-          description: 'The path to the local package to install'
+          description: 'The path to the package in the local file system'
 property :sensor_tmp_dir, String, default: '/tmp', desired_state: false,
           description: 'The directory to stage the Falcon package in'
 

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -19,8 +19,10 @@ property :falcon_cloud, String, default: 'api.crowdstrike.com', desired_state: f
           description: 'The Falcon API cloud to use'
 property :cleanup_installer, [true, false], default: true, desired_state: false,
           description: 'Whether or not to cleanup the installer after installation'
-property :install_method, ['api'], default: 'api', desired_state: false,
+property :install_method, String, equal_to: %w(api local), default: 'api', desired_state: false,
           description: 'The method to use to install the Falcon sensor'
+property :package_source, String, desired_state: false,
+          description: 'The path to the local package to install'
 property :sensor_tmp_dir, String, default: '/tmp', desired_state: false,
           description: 'The directory to stage the Falcon package in'
 
@@ -39,8 +41,7 @@ end
 PACKAGE_NAME = 'falcon-sensor'.freeze
 
 action :install do
-  # Create file with contents
-
+  # Download the falcon package from API
   if new_resource.install_method == 'api'
     if new_resource.client_id.nil? || new_resource.client_secret.nil?
       raise ArgumentError, 'client_id and client_secret are required when using the api install method'
@@ -62,27 +63,38 @@ action :install do
         action :create
       end
     end
-
-    package 'falcon' do
-      source sensor_info['file_path']
-      only_if { ::File.exist?(sensor_info['file_path']) }
-      provider Chef::Provider::Package::Dpkg if debian?
-      options '--force-all' if debian?
-      action :install
-      notifies :run, 'execute[falcon]', :immediately if debian?
+  else
+    # install_method == 'local'
+    if new_resource.package_source.nil?
+      raise ArgumentError, 'package_source is required when using the local install method'
     end
 
-    # Only run on debian based systems after package install
-    execute 'falcon' do
-      command 'apt -f -y install'
-      only_if { debian? }
-      action :nothing
-    end
+    sensor_info = {
+      'file_path' => new_resource.package_source,
+    }
+  end
 
-    if new_resource.cleanup_installer
-      file sensor_info['file_path'] do
-        action :delete
-      end
+  package 'falcon' do
+    source sensor_info['file_path']
+    only_if { ::File.exist?(sensor_info['file_path']) }
+    provider Chef::Provider::Package::Dpkg if debian?
+    options '--force-all' if debian?
+    action :install
+    notifies :run, 'execute[falcon]', :immediately if debian?
+  end
+
+  # Only run on debian based systems after package install
+  execute 'falcon' do
+    command 'apt -f -y install'
+    only_if { debian? }
+    action :nothing
+  end
+
+  # if new_resource.cleanup_installer
+  if new_resource.install_method == 'api'
+    file sensor_info['file_path'] do
+      action :delete
+      only_if { new_resource.cleanup_installer }
     end
   end
 end

--- a/test/cookbooks/test/recipes/install_local.rb
+++ b/test/cookbooks/test/recipes/install_local.rb
@@ -1,0 +1,15 @@
+execute 'download' do
+  command 'curl -L https://raw.githubusercontent.com/carlosmmatos/falcon-scripts/chef-pre-converge/bash/install/falcon-linux-install.sh | FALCON_CLOUD=us-1 bash'
+  action :run
+  # not_if package falcon-sensor exists
+  not_if { ::File.directory?('/opt/CrowdStrike') }
+end
+
+falcon_install 'falcon' do
+  install_method 'local'
+  # Use shell_out to get the path to the falcon package
+  package_source shell_out('find /tmp | grep falcon-sensor').stdout.strip
+  action :install
+end
+
+include_recipe 'test::common'

--- a/test/integration/install_api_policy/controls/default.rb
+++ b/test/integration/install_api_policy/controls/default.rb
@@ -1,4 +1,4 @@
-falcon_version = '6.47.0-14408' # This is from Sensor Update Policy
+falcon_version = '6.48.0-14504' # This is from Sensor Update Policy
 
 # Include common controls
 include_controls 'common'

--- a/test/integration/install_local/controls/default.rb
+++ b/test/integration/install_local/controls/default.rb
@@ -1,0 +1,4 @@
+# Include common controls
+include_controls 'common' do
+  skip_control 'cleanup-installer'
+end

--- a/test/integration/install_local/inspec.yml
+++ b/test/integration/install_local/inspec.yml
@@ -1,0 +1,8 @@
+name: install-local
+title: Install using local file
+summary: Verify the local falcon-sensor is installed
+supports:
+  - platform-family: linux
+depends:
+  - name: common
+    path: test/integration/common


### PR DESCRIPTION
closes #15 

This PR introduces the ability to specify a local path where the falcon-sensor can be installed from.

TODO:

- [x] Add new documentation to install resource