### PR TITLE
Add --backend + fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       github.event_name == 'schedule' ||
       (github.event_name == 'pull_request_target' &&
       github.event.label.name == 'ok-to-test')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         os:

--- a/ohai/falcon.rb
+++ b/ohai/falcon.rb
@@ -69,6 +69,10 @@ Ohai.plugin(:Falcon) do
     falconctl_shell_out('billing')
   end
 
+  def get_backend
+    falconctl_shell_out('backend')
+  end
+
   collect_data(:default) do
     falcon Mash.new
     falcon[:version] = [packages['falcon-sensor']['version'], packages['falcon-sensor']['release']].join('-') if packages['falcon-sensor']
@@ -83,5 +87,6 @@ Ohai.plugin(:Falcon) do
     falcon[:proxy][:host] = get_aph
     falcon[:proxy][:port] = get_app
     falcon[:billing] = get_billing
+    falcon[:backend] = get_backend
   end
 end

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -15,7 +15,7 @@ property :tags, Array, default: [],
           description: 'The tags to set on the agent'
 property :provisioning_token, String, desired_state: false,
           description: 'The provisioning token to use to register the agent'
-property :backend, String, equal_to: %w(auto bpf kernel), desired_state: false,
+property :backend, String, equal_to: %w(auto bpf kernel),
           description: 'The type of backend to use for the sensor [auto, bpf, kernel]'
 property :tag_membership, %w(minimum inclusive), default: 'minimum', desired_state: false,
           description: 'Whether specified tags should be treated as a complete list `inclusive` or as a list of tags to add to the existing list `minimum`'
@@ -52,6 +52,7 @@ load_current_value do |new_resource|
   proxy_host node.dig('falcon', 'proxy', 'host')
   proxy_port node.dig('falcon', 'proxy', 'port').to_i # TODO: ensure it will not fail if nil
   proxy_enabled node.dig('falcon', 'proxy', 'enabled')
+  backend node.dig('falcon', 'backend')
 end
 
 def delete_option(option)

--- a/test/cookbooks/test/recipes/common.rb
+++ b/test/cookbooks/test/recipes/common.rb
@@ -1,6 +1,7 @@
 # Common recipes for most instllations
 falcon_config 'falcon' do
   cid ENV['FALCON_CID']
+  backend 'kernel'
   notifies :restart, 'falcon_service[falcon]', :delayed
   action :set
 end

--- a/test/integration/common/controls/default.rb
+++ b/test/integration/common/controls/default.rb
@@ -28,6 +28,13 @@ control 'config-cid' do
   end
 end
 
+control 'config-backend' do
+  desc 'Backend should be set to kernel'
+  describe command('/opt/CrowdStrike/falconctl -g --backend') do
+    its('stdout') { should match /backend=kernel/ }
+  end
+end
+
 control 'cleanup-installer' do
   desc 'Installer should be removed'
   describe command('find /tmp | grep "falcon-sensor"').stdout.strip do


### PR DESCRIPTION
Fixes #35 
Fixes #37 

This PR introduces a new option for falcon_config: `--backend`

This option sets the preferred backend for the sensor to use and consists of 3 choices:
- Auto
- BPF
- Kernel

Because of the new sensor backend option, this PR updates the CI roles to not check for aid since that becomes finicky with the way the sensor starts.