### PR TITLE
Add changelog for last release to not forget in next one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,12 @@ Initial release.
 - Added badge to README for cookbook in supermarket by @carlosmmatos in <https://github.com/CrowdStrike/chef-falcon/pull/19>
 - Update readme to include full links by @carlosmmatos in <https://github.com/CrowdStrike/chef-falcon/pull/20>
 - Integration Testing by @carlosmmatos in <https://github.com/CrowdStrike/chef-falcon/pull/21>
+
+## v0.1.2
+
+**Full Changelog**: <https://github.com/CrowdStrike/chef-falcon/compare/0.1.1...v0.1.2>
+
+- Decrement int test by @carlosmmatos in <https://github.com/CrowdStrike/chef-falcon/pull/29>
+- Add local install_method to install falcon from local file source by @carlosmmatos in <https://github.com/CrowdStrike/chef-falcon/pull/30>
+- Update ci and fix local install by @carlosmmatos in <https://github.com/CrowdStrike/chef-falcon/pull/31>
+- Fix issue with s390x support on sensor API by @carlosmmatos in <https://github.com/CrowdStrike/chef-falcon/pull/34>


### PR DESCRIPTION
Forgot to include changelog updates in v0.1.2 release.. This is just to ensure we don't forget it on the next release