### PR TITLE
Added new FALCON_VERSIONS to nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,3 +18,4 @@ jobs:
       FALCON_CLIENT_SECRET: ${{ secrets.FALCON_CLIENT_SECRET }}
       FALCON_CID: ${{ secrets.FALCON_CID }}
       FALCON_CLOUD: ${{ secrets.FALCON_CLOUD }}
+      FALCON_VERSION: ${{ secrets.FALCON_VERSION }}


### PR DESCRIPTION
This PR fixes the nightly issues error because it was not passing the new FALCON_VERSION secrets to the ci.yml workflow.