### PR TITLE
Update policy api test

### DIFF
--- a/test/integration/install_api_policy/controls/default.rb
+++ b/test/integration/install_api_policy/controls/default.rb
@@ -1,9 +1,2 @@
-falcon_version = '6.48.0-14504' # This is from Sensor Update Policy
-
-# Include common controls
+# Include common::installed tests
 include_controls 'common'
-
-# Ensure falcon-sensor package installed to specific version
-describe package('falcon-sensor') do
-  its('version') { should match falcon_version }
-end


### PR DESCRIPTION
We only need to ensure package is installed.

No need to check for a specific version. If this succeeds, then we know the policy worked.